### PR TITLE
Copy secrets delete option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # AWS Utils
 
+Use at own risk
+
 AWS utilities written in Golang:
 1. [copySecrets](copySecrets) -- copy an existing secret under a new name

--- a/copySecrets/README.md
+++ b/copySecrets/README.md
@@ -9,3 +9,6 @@ where:
 1. `<region_name>` -- name of the AWS region for the session
 1. `<original_name>` -- friendly name of the existing secret
 1. `<new_name>` -- friendly name of the new secret
+
+You can used the `--delete` flag to delete the existing/original secret after it
+has been copied.


### PR DESCRIPTION
It is useful to delete the existing/original secret after copying it.
The PR gives the option to do that in the CopySecrets utility.

In addition, added disclaimer about usage risks.